### PR TITLE
Fix LinkType, add locale in link title

### DIFF
--- a/Form/Type/LinkType.php
+++ b/Form/Type/LinkType.php
@@ -70,7 +70,8 @@ class LinkType extends AbstractType
 
                 foreach ($entities as $entity) {
                     $clazz = $this->doctrine->getManager()->getClassMetadata(get_class($entity))->getName();
-                    $data[$displayName][$entity->__toString()] = $entity->getId().';'.$clazz;
+                    $data[$displayName][$entity->__toString().($entity->getLocale() !== TreeNodeInterface::UNKNOWN_LOCALE
+                        ? ' ('.$entity->getLocale().')':'')] = $entity->getId().';'.$clazz;
                 }
             }
 


### PR DESCRIPTION
Menus link are not translatable, all links are displayed. This PR adds the locale in link title to facilitate contributions
