### PR TITLE
fix: wrong return value in repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Return value of `NodeHistoryRepository->getByPath()` changed from `Node` to `NodeHistory`
+
 ## [1.0.6] - 2023-04-13
 
 ### Fixed

--- a/Repository/NodeHistoryRepository.php
+++ b/Repository/NodeHistoryRepository.php
@@ -4,6 +4,7 @@ namespace Umanit\TreeBundle\Repository;
 
 use Doctrine\ORM\EntityRepository;
 use Umanit\TreeBundle\Entity\Node;
+use Umanit\TreeBundle\Entity\NodeHistory;
 use Umanit\TreeBundle\Model\TreeNodeInterface;
 
 class NodeHistoryRepository extends EntityRepository
@@ -17,10 +18,10 @@ class NodeHistoryRepository extends EntityRepository
      *
      * @return Node|null
      */
-    public function getByPath(string $path, string $locale = TreeNodeInterface::UNKNOWN_LOCALE): ?Node
+    public function getByPath(string $path, string $locale = TreeNodeInterface::UNKNOWN_LOCALE): ?NodeHistory
     {
         if ($path[0] !== '/') {
-            $path = '/'.$path;
+            $path = '/' . $path;
         }
 
         $qb = $this


### PR DESCRIPTION
- Return value of `NodeHistoryRepository->getByPath()` changed from `Node` to `NodeHistory`