### PR TITLE
fix: Symfony 7 compatibility fixes (IsGranted, empty path, command names)

### DIFF
--- a/Command/InitializeCommand.php
+++ b/Command/InitializeCommand.php
@@ -3,16 +3,16 @@
 namespace Umanit\TreeBundle\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Umanit\TreeBundle\Entity\Node;
 use Umanit\TreeBundle\Model\TreeNodeInterface;
 
+#[AsCommand(name: 'umanit:tree:initialize')]
 class InitializeCommand extends Command
 {
-    protected static $defaultName = 'umanit:tree:initialize';
-
     private ?string $rootClass;
     private EntityManagerInterface $em;
 

--- a/Command/RefreshNodesCommand.php
+++ b/Command/RefreshNodesCommand.php
@@ -3,15 +3,15 @@
 namespace Umanit\TreeBundle\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Umanit\TreeBundle\Helper\NodeHelper;
 
+#[AsCommand(name: 'umanit:tree:refresh')]
 class RefreshNodesCommand extends Command
 {
-    protected static $defaultName = 'umanit:tree:refresh';
-
     private NodeHelper $nodeHelper;
     private array $nodeTypes;
     private EntityManagerInterface $em;

--- a/Controller/MenuAdminController.php
+++ b/Controller/MenuAdminController.php
@@ -3,7 +3,6 @@
 namespace Umanit\TreeBundle\Controller;
 
 use Doctrine\Persistence\ManagerRegistry;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -11,6 +10,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[IsGranted('ROLE_TREE_MENU_ADMIN')]
 class MenuAdminController extends AbstractController

--- a/Entity/AbstractMenu.php
+++ b/Entity/AbstractMenu.php
@@ -127,7 +127,7 @@ abstract class AbstractMenu
     #[ORM\PreUpdate]
     public function update()
     {
-        $this->updatedAt = new \DateTimeImmutable();
+        $this->updatedAt = new \DateTime();
     }
 
     public function getUpdatedAt(): ?\DateTimeInterface

--- a/Repository/NodeRepository.php
+++ b/Repository/NodeRepository.php
@@ -64,7 +64,7 @@ class NodeRepository extends MaterializedPathRepository
      */
     public function getByPath(string $path, string $locale = TreeNodeInterface::UNKNOWN_LOCALE): ?Node
     {
-        if ($path[0] !== '/') {
+        if ('' === (string) $path || $path[0] !== '/') {
             $path = '/'.$path;
         }
 


### PR DESCRIPTION
- `MenuAdminController`: replace the removed `SensioFrameworkExtraBundle` `IsGranted` attribute with `Symfony\Component\Security\Http\Attribute\IsGranted`.
- `NodeRepository::getByPath()`: guard against an empty path before checking `$path[0]`, avoiding an error on empty string.
- `InitializeCommand`/`RefreshNodesCommand`: replace the no-longer-read `protected static $defaultName` with `#[AsCommand(name: ...)]` — Symfony Console 7.4's `Command::__construct()` no longer reads the static property, so these commands ended up with an empty name.